### PR TITLE
Remove dependencies to template-library

### DIFF
--- a/template-service/CMakeLists.txt
+++ b/template-service/CMakeLists.txt
@@ -13,7 +13,7 @@ include(GNUInstallDirs)
 add_compile_options(-std=c++14)
 
 # Check dependencies
-pkg_check_modules(TEMPLATE-LIBRARY "template-library >= 0.1.0" REQUIRED)
+# pkg_check_modules(TEMPLATE-LIBRARY "template-library >= 0.1.0" REQUIRED)
 
 # Project targets
 set(TARGET ${PROJECT_NAME})
@@ -23,14 +23,14 @@ include_directories(src)
 file(GLOB SOURCE_FILES "src/*.cpp" "src/*.h")
 
 # Include dependency directories
-include_directories(${TEMPLATE-LIBRARY_INCLUDE_DIRS})
-link_directories(${TEMPLATE-LIBRARY_LIBRARY_DIRS})
+# include_directories(${TEMPLATE-LIBRARY_INCLUDE_DIRS})
+# link_directories(${TEMPLATE-LIBRARY_LIBRARY_DIRS})
 
 # Declare target executable
 add_executable(${TARGET} ${SOURCE_FILES})
 
 # Link libraries
-target_link_libraries(${TARGET} ${TEMPLATE-LIBRARY_LIBRARIES})
+# target_link_libraries(${TARGET} ${TEMPLATE-LIBRARY_LIBRARIES})
 
 # Install directives
 install(TARGETS ${TARGET} DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/template-service/src/main.cpp
+++ b/template-service/src/main.cpp
@@ -9,15 +9,17 @@
  *
  */
 
-#include <template-library/templatepublicclass.h>
+// #include <template-library/templatepublicclass.h>
 
 #include <iostream>
 #include <memory>
 
 int main(int argc, char const **argv)
 {
+    /*
     std::shared_ptr<TemplatePublicClass> templatePublicInstance(new TemplatePublicClass());
     templatePublicInstance->templateFunction();
+    */
 
     std::cout << "Hello from Template Service!\n";
 


### PR DESCRIPTION
As it is not possible to simply pull template-service and use it without also having to run intricate renaming scripts. I think it is better to keep the template-service and the template generated by this wizard as two different (although very similar) things.

This also allows us to have more wizard specifics etc..

Signed-off-by: Viktor Sjölind <viktor.sjolind@pelagicore.com>